### PR TITLE
Changed CloudHealth time intervals

### DIFF
--- a/krux_cloud_health/cli.py
+++ b/krux_cloud_health/cli.py
@@ -77,9 +77,14 @@ class Application(krux.cli.Application):
     def run(self):
         try:
             cost_history = self.cloud_health.cost_history(self.interval)
+
+            # If no date_input, cost_data is most recent data available for given time interval in cost_history
             if self.date_input is None:
                 cost_data = cost_history.pop()
-                self.date_input = cost_data.keys()[0]
+                for item, data in cost_data[cost_data.keys()[0]]:
+                    self.stats.incr(item, data)
+                self.exit(1)
+            # If date_input provided, search through cost_history until dictionary corresponding to date_input is found
             else:
                 cost_data = [cost_history[i] for i in range(len(cost_history)) if cost_history[i].keys()[0] == self.date_input][0]
         except (ValueError, IndexError) as e:

--- a/krux_cloud_health/cli.py
+++ b/krux_cloud_health/cli.py
@@ -71,7 +71,7 @@ class Application(krux.cli.Application):
             '--set-date',
             type=str,
             default=None,
-            help="Retrieve cost history data for specific date, depending on interval. (ex: 'YYYY-MM-DD' for day)",
+            help="Retrieve cost history data for specific date, depending on interval. (ex: 'YYYY-MM-DD' for daily)",
         )
 
     def run(self):

--- a/krux_cloud_health/cli.py
+++ b/krux_cloud_health/cli.py
@@ -16,7 +16,6 @@ from __future__ import absolute_import
 # Third party libraries
 #
 
-import datetime
 
 #
 # Internal libraries

--- a/krux_cloud_health/cli.py
+++ b/krux_cloud_health/cli.py
@@ -16,7 +16,7 @@ from __future__ import absolute_import
 # Third party libraries
 #
 
-from datetime import date, timedelta
+import datetime
 
 #
 # Internal libraries
@@ -25,7 +25,8 @@ from datetime import date, timedelta
 import krux.cli
 from krux.logging import get_logger
 from krux.cli import get_group
-from krux_cloud_health.cloud_health import CloudHealth, NAME, INTERVAL, add_cloud_health_cli_arguments, get_cloud_health
+from krux_cloud_health.cloud_health import CloudHealth, Interval, NAME, add_cloud_health_cli_arguments, get_cloud_health
+
 
 class Application(krux.cli.Application):
     def __init__(self, name=NAME):
@@ -41,16 +42,12 @@ class Application(krux.cli.Application):
             self.logger.error(e.message)
             self.exit(1)
 
-        self.interval = self.args.interval
+        self.interval = Interval[self.args.interval]
 
         if self.args.set_date is not None:
             self.date_input = self.args.set_date
         else:
-            today = date.today()
-            if self.interval == 'daily':
-                self.date_input = '{0}'.format(today - timedelta(days=1))
-            elif self.interval == 'monthly':
-                self.date_input = '{0}-{1}'.format(today.year, '%02d' % today.month)
+            self.date_input = None
 
     def add_cli_arguments(self, parser):
         """
@@ -66,8 +63,8 @@ class Application(krux.cli.Application):
         group.add_argument(
             '--interval',
             type=str,
-            choices=INTERVAL,
-            default='daily',
+            choices=[i.name for i in Interval],
+            default=Interval.daily.name,
             help="Set time interval of data (default: %(default)s)",
         )
 
@@ -75,20 +72,21 @@ class Application(krux.cli.Application):
             '--set-date',
             type=str,
             default=None,
-            help="Retrieve cost history data for specific day ('YYYY-MM-DD') or month ('YYYY-MM'), depending on interval.",
+            help="Retrieve cost history data for specific date, depending on interval. (ex: 'YYYY-MM-DD' for day)",
         )
 
     def run(self):
         try:
-            if self.interval == 'daily':
-                cost_history = self.cloud_health.cost_history_day(self.date_input)
-            elif self.interval == 'monthly':
-                cost_history = self.cloud_health.cost_history_month(self.date_input)
-        except ValueError as e:
+            cost_history = self.cloud_health.cost_history(self.interval)
+            if self.date_input is None:
+                cost_data = cost_history.pop()
+                self.date_input = cost_data.keys()[0]
+            else:
+                cost_data = [cost_history[i] for i in range(len(cost_history)) if cost_history[i].keys()[0] == self.date_input][0]
+        except (ValueError, IndexError) as e:
             self.logger.error(e.message)
             self.exit(1)
-
-        for item, data in cost_history[self.date_input].iteritems():
+        for item, data in cost_data[self.date_input].iteritems():
             self.stats.incr(item, data)
 
 

--- a/krux_cloud_health/cli_test.py
+++ b/krux_cloud_health/cli_test.py
@@ -47,8 +47,11 @@ class Application(krux.cli.Application):
         # cost_history = self.cloud_health.cost_history_day("2016-06-23")
         # self.logger.debug(pprint.pformat(cost_history, indent=2, width=20))
 
-        cost_current = self.cloud_health.cost_current()
-        self.logger.debug(pprint.pformat(cost_current, indent=2, width=20))
+        cost_history = self.cloud_health.cost_history("weekly")
+        self.logger.debug(pprint.pformat(cost_history, indent=2, width=20))
+
+        # cost_current = self.cloud_health.cost_current()
+        # self.logger.debug(pprint.pformat(cost_current, indent=2, width=20))
 
 def main():
     app = Application()

--- a/krux_cloud_health/cli_test.py
+++ b/krux_cloud_health/cli_test.py
@@ -20,7 +20,7 @@ import pprint
 import krux.cli
 from krux.cli import get_group
 from krux.logging import get_logger
-from krux_cloud_health.cloud_health import CloudHealth, NAME, add_cloud_health_cli_arguments, get_cloud_health
+from krux_cloud_health.cloud_health import CloudHealth, Interval, NAME, add_cloud_health_cli_arguments, get_cloud_health
 
 
 class Application(krux.cli.Application):
@@ -44,10 +44,7 @@ class Application(krux.cli.Application):
         group = get_group(parser, self.name)
 
     def run(self):
-        # cost_history = self.cloud_health.cost_history_day("2016-06-23")
-        # self.logger.debug(pprint.pformat(cost_history, indent=2, width=20))
-
-        cost_history = self.cloud_health.cost_history("weekly")
+        cost_history = self.cloud_health.cost_history(Interval.weekly)
         self.logger.debug(pprint.pformat(cost_history, indent=2, width=20))
 
         # cost_current = self.cloud_health.cost_current()

--- a/krux_cloud_health/cloud_health.py
+++ b/krux_cloud_health/cloud_health.py
@@ -19,6 +19,7 @@ import urlparse
 #
 
 import requests
+from enum import Enum
 
 #
 # Internal libraries
@@ -29,7 +30,13 @@ from krux.cli import get_parser, get_group
 
 API_ENDPOINT = "https://apps.cloudhealthtech.com/"
 NAME = "cloud-health-tech"
-INTERVAL = ['daily', 'monthly']
+
+
+class Interval(Enum):
+    hourly = 1
+    daily = 2
+    weekly = 3
+    monthly = 4
 
 
 def add_cloud_health_cli_arguments(parser):
@@ -68,23 +75,7 @@ class CloudHealth(object):
         self.logger = logger
         self.stats = stats
 
-    def cost_history_month(self, month_input=None):
-        """
-        Cost history for specified month.
-
-        :argument month_input: month for which data is retrieved (optional)
-        """
-        return self._cost_history("monthly", month_input)
-
-    def cost_history_day(self, day_input=None):
-        """
-        Cost history for specified day.
-
-        :argument month_input: month for which data is retrieved (optional)
-        """
-        return self._cost_history("daily", day_input)
-
-    def _cost_history(self, time_interval, time_input):
+    def cost_history(self, time_interval, time_input=None):
         """
         Cost history for specified time interval and input.
     
@@ -100,7 +91,7 @@ class CloudHealth(object):
 
         items_list = dimensions[1].get('AWS-Service-Category', {})
 
-        return self._get_data(api_call, items_list, time_list, time_input, time_interval)
+        return self._get_data(api_call, items_list, time_list, time_interval, time_input)
 
     def cost_current(self, aws_account_input=None):
         """
@@ -128,7 +119,7 @@ class CloudHealth(object):
         :argument api_key: API allows data to be retrieved
         :argument time_interval: Filters data from API call for specific time interval
         """
-        uri_args = {'api_key': api_key, 'interval': time_interval}
+        uri_args = {'api_key': api_key, 'interval': time_interval.name}
         uri = urlparse.urljoin(API_ENDPOINT, report)
         r = requests.get(uri, params=uri_args)
         api_call = r.json()
@@ -136,7 +127,7 @@ class CloudHealth(object):
             raise ValueError(api_call['error'])
         return api_call
 
-    def _get_data(self, api_call, items_list, category_list, category_input, category_type):
+    def _get_data(self, api_call, items_list, category_list, category_type, category_input=None):
         """
         Retrieves data from API call for 
 

--- a/requirements.pip
+++ b/requirements.pip
@@ -6,6 +6,9 @@ krux-stdlib==2.2.1
 # Requests information from API webpages
 requests==2.10.0
 
+# For enum parameters in CLI
+enum34==1.1.6
+
 # Transitive Dependencies
 
 # From krux-stdlib


### PR DESCRIPTION
Because Cloud Health is not updated as regularly as I had anticipated, I no longer use datetime in cli.py to get the most current date. Instead, I retrieve all the data for a specific time interval (ex: day, week) from the API in cloud_health.py and choose the most current date available from said data in cli.py. I also changed the time Interval data from a list to an enum in cloud_health.py. 
