### PR TITLE
Fixing SNIMissingWarning error

### DIFF
--- a/requirements.pip
+++ b/requirements.pip
@@ -9,6 +9,10 @@ requests==2.10.0
 # For enum parameters in CLI
 enum34==1.1.6
 
+# This makes sure SNI support is there and SNIMissingWarning is not thrown
+# Refer to http://urllib3.readthedocs.io/en/latest/user-guide.html#ssl-py2
+urllib3[secure]==1.16
+
 # Transitive Dependencies
 
 # From krux-stdlib
@@ -29,3 +33,15 @@ async==0.6.1
 fudge==1.0.3
 gitdb==0.5.4
 smmap==0.8.2
+
+# From urllib3[secure]
+certifi==2016.8.8
+cffi==1.7.0
+cryptography==1.4
+idna==2.1
+ipaddress==1.0.16
+ndg-httpsclient==0.4.2
+pyOpenSSL==16.0.0
+pyasn1==0.1.9
+pycparser==2.14
+urllib3==1.16

--- a/requirements.pip
+++ b/requirements.pip
@@ -1,7 +1,7 @@
 --extra-index-url https://staticfiles.krxd.net/foss/pypi/
 
 # Krux's standard library, which this is built on
-krux-stdlib==2.2.1
+krux-stdlib==2.3.0
 
 # Requests information from API webpages
 requests==2.10.0


### PR DESCRIPTION
#### What's this PR do?

This PR upgrades `krux-stdlib` to the latest version and also includes `urllib3[secure]` package to deal with the lack of SNI support in older version of python.
#### Where should the reviewer start?

`requirements.pip`
#### How was this PR manually tested?

A debian package was manually built in `ci-a-trusty-worker003.krxd.net` and deployed to `periodic-a006.krxd.net`. The same command as the kcron job in `periodic-a004.krxd.net` was executed. No warning was thrown.
#### Any background context you want to provide?

As of now, the warning appears on every execution, causing cronjob to send an email each execution. The right fix for this is to upgrade python version to `> 2.7.9`. Neither Lucid or Trusty comes with that version. This PR will install the SNI support needed using external libraries.

**NOTE:** This change requires `libc6` package with version `> 2.14` or `> 2.15`. On Lucid, the last version released is `2.11`. This change makes this library unavailable for Lucid.
