### PR TITLE
PE-2637: Add --date-format

### DIFF
--- a/bin/cloud_health_to_graphite.py
+++ b/bin/cloud_health_to_graphite.py
@@ -76,6 +76,13 @@ class Application(krux_cloud_health.cli.Application):
             help="Retrieve cost history data for specific date, depending on interval. (ex: 'YYYY-MM-DD' for daily)",
         )
 
+        group.add_argument(
+            '--date-format',
+            type=str,
+            default='%Y-%m-%d',
+            help="Format string to use to parse the date passed by Cloud Health (default: %(default)s)",
+        )
+
     @staticmethod
     def _sanitize_stats(stat_name):
         return re.sub(Application._INVALID_STATS_PATTERN, '_', stat_name)
@@ -93,7 +100,7 @@ class Application(krux_cloud_health.cli.Application):
             del report_data['Total']
 
         for date, values in iteritems(report_data):
-            date = int(calendar.timegm(datetime.strptime(date, '%Y-%m-%d').utctimetuple()))
+            date = int(calendar.timegm(datetime.strptime(date, self.args.date_format).utctimetuple()))
 
             for category, cost in iteritems(values):
                 # XXX: Empty space and period causes issues with graphite. Replace it with underscore.

--- a/krux_cloud_health/__init__.py
+++ b/krux_cloud_health/__init__.py
@@ -1,1 +1,1 @@
-VERSION = '0.2.0'
+VERSION = '0.2.1'

--- a/tests/bin/cloud_health_to_graphite_test.py
+++ b/tests/bin/cloud_health_to_graphite_test.py
@@ -75,7 +75,7 @@ class CloudHealthAPITest(unittest.TestCase):
 
     def test_init(self):
         """
-        Cloud Health API Test: All private fields are properly created in __init__
+        Cloud Health to Graphite: All private fields are properly created in __init__
         """
         # Verify report_name field is created
         self.assertEqual(self.REPORT_NAME, self.app.report_name)
@@ -86,7 +86,7 @@ class CloudHealthAPITest(unittest.TestCase):
 
     def test_add_cli_arguments(self):
         """
-        Cloud Health API Test: All arguments from present in the args
+        Cloud Health to Graphite: All arguments from present in the args
         """
         self.assertIn('api_key', self.app.args)
         self.assertIn('report_id', self.app.args)
@@ -101,6 +101,10 @@ class CloudHealthAPITest(unittest.TestCase):
         self.assertEqual(self._DEFAULT_DATE_FORMAT, self.app.args.date_format)
 
     def test_run_error(self):
+        """
+        Cloud Health to Graphite: The application correctly errors out when report data cannot be retrieved
+        from Cloud Health
+        """
         error = ValueError('Error message')
 
         self.app.cloud_health.get_custom_report = MagicMock(side_effect=error)
@@ -112,7 +116,7 @@ class CloudHealthAPITest(unittest.TestCase):
     @patch('sys.stdout', new_callable=StringIO)
     def test_run_without_set_date(self, mock_stdout):
         """
-        Cloud Health API Test: Cloud Health's cost_history and cost_current methods are correctly called in self.app.run()
+        Cloud Health to Graphite: Cloud Health's report data is correctly displayed to stdout to be sent to graphite.
         """
         self.app.run()
 
@@ -147,6 +151,9 @@ class CloudHealthAPITest(unittest.TestCase):
     @patch('sys.argv', ['prog', API_KEY, REPORT_ID_ARG, '--report-name', REPORT_NAME_ARG, '--set-date', SET_DATE])
     @patch('sys.stdout', new_callable=StringIO)
     def test_run_with_set_date(self, mock_stdout):
+        """
+        Cloud Health to Graphite: Only the designated date's data is displayed to stdout when --set-date is used
+        """
         app = Application()
         app.cloud_health.get_custom_report = MagicMock(side_effect=CloudHealthAPITest._get_cloud_health_return)
 
@@ -172,6 +179,9 @@ class CloudHealthAPITest(unittest.TestCase):
     @patch('sys.argv', ['prog', API_KEY, REPORT_ID_ARG, '--report-name', REPORT_NAME_ARG, '--date-format', DATE_FORMAT])
     @patch('sys.stdout', new_callable=StringIO)
     def test_run_with_set_date(self, mock_stdout):
+        """
+        Cloud Health to Graphite: The date in the data is correctly parsed with the passed --date-format
+        """
         app = Application()
         # Create a lambda function that calls _get_cloud_health_return() with CloudHealthAPITest.DATE_FORMAT
         # This is because side_effect can only take a function pointer
@@ -208,7 +218,7 @@ class CloudHealthAPITest(unittest.TestCase):
 
     def test_main(self):
         """
-        Cloud Health API Test: Application is instantiated and run() is called in main()
+        Cloud Health to Graphite: Application is instantiated and run() is called in main()
         """
         app = MagicMock()
         app_class = MagicMock(return_value=app)

--- a/tests/krux_cloud_health/cloud_health_test.py
+++ b/tests/krux_cloud_health/cloud_health_test.py
@@ -39,36 +39,41 @@ class CloudHealthTest(unittest.TestCase):
     PARAMS_TIME_INPUT = {'interval': 'daily', 'filters[]': 'time:select:{}'.format(TIME_INPUT)}
     API_CALL = {'api_call': 'return'}
     API_CALL_ERROR = {'error': 'Error message'}
-    ITEMS_LIST = [{'label': 'service1', 'parent': -1},
-                    {'label': 'service2', 'parent': 1},
-                    {'label': 'service3', 'parent': 1}]
-    GET_DATA_API_CALL = {'dimensions': [
-                            {'time':
-                                [
-                                    {'label': 'date1'},
-                                    {'label': 'date2'}
-                                ]
-                            },
-                            {'AWS-Service-Category':
-                                ITEMS_LIST}
-                        ],
-
-                        'data': [
-                            [
-                                [1],
-                                [2.24555],
-                                [None]
-                            ],
-                            [
-                                [3],
-                                [4.1111],
-                                [None]
-                            ]
-                        ]
-                    }
+    ITEMS_LIST = [
+        {'label': 'service1', 'parent': -1},
+        {'label': 'service2', 'parent': 1},
+        {'label': 'service3', 'parent': 1},
+    ]
+    GET_DATA_API_CALL = {
+        'dimensions': [
+            {
+                'time': [
+                    {'label': 'date1'},
+                    {'label': 'date2'}
+                ]
+            },
+            {
+                'AWS-Service-Category': ITEMS_LIST
+            },
+        ],
+        'data': [
+            [
+                [1],
+                [2.24555],
+                [None],
+            ],
+            [
+                [3],
+                [4.1111],
+                [None],
+            ]
+        ]
+    }
     GET_DATA_INFO_RV = {'date1': {'service2': 2.25, 'service3': None}}
-    GET_DATA_RV = {'date1': {'service2': 2.25, 'service3': None},
-            'date2': {'service2': 4.11, 'service3': None}}
+    GET_DATA_RV = {
+        'date1': {'service2': 2.25, 'service3': None},
+        'date2': {'service2': 4.11, 'service3': None},
+    }
 
     def setUp(self):
         self.cloud_health = get_cloud_health(args=MagicMock(api_key=CloudHealthTest.API_KEY))
@@ -86,10 +91,10 @@ class CloudHealthTest(unittest.TestCase):
         get_cloud_health()
 
         mock_cloud_health.assert_called_once_with(
-            api_key = CloudHealthTest.API_KEY,
+            api_key=CloudHealthTest.API_KEY,
             logger=mock_logger(name=NAME),
             stats=mock_stats(prefix=NAME),
-            )
+        )
 
     @patch('krux_cloud_health.cloud_health.get_stats')
     @patch('krux_cloud_health.cloud_health.get_logger')
@@ -103,10 +108,10 @@ class CloudHealthTest(unittest.TestCase):
         get_cloud_health(mock_args, mock_logger, mock_stats)
 
         mock_cloud_health.assert_called_once_with(
-            api_key = CloudHealthTest.API_KEY,
+            api_key=CloudHealthTest.API_KEY,
             logger=mock_logger,
             stats=mock_stats,
-            )
+        )
 
     def test_cost_history_time_input(self):
         """
@@ -122,15 +127,16 @@ class CloudHealthTest(unittest.TestCase):
             CloudHealthTest.COST_HISTORY_REPORT,
             CloudHealthTest.API_KEY,
             CloudHealthTest.PARAMS_TIME_INPUT,
-            )
+        )
         self.cloud_health._get_data.assert_called_once_with(
             self.cloud_health._get_api_call(
                 CloudHealthTest.COST_HISTORY_REPORT,
                 CloudHealthTest.API_KEY,
-                CloudHealthTest.PARAMS_TIME_INPUT),
-                CloudHealthTest.COST_HISTORY_CATEGORY_TYPE,
-                CloudHealthTest.TIME_INPUT
-                )
+                CloudHealthTest.PARAMS_TIME_INPUT
+            ),
+            CloudHealthTest.COST_HISTORY_CATEGORY_TYPE,
+            CloudHealthTest.TIME_INPUT
+        )
 
     def test_cost_history_no_time_input(self):
         """
@@ -146,11 +152,12 @@ class CloudHealthTest(unittest.TestCase):
             CloudHealthTest.COST_HISTORY_REPORT,
             CloudHealthTest.API_KEY,
             CloudHealthTest.PARAMS_INTERVAL,
-            )
+        )
         self.cloud_health._get_data.assert_called_once_with(
             CloudHealthTest.API_CALL,
             CloudHealthTest.COST_HISTORY_CATEGORY_TYPE,
-            None)
+            None,
+        )
 
     def test_cost_current(self):
         """
@@ -163,12 +170,13 @@ class CloudHealthTest(unittest.TestCase):
 
         self.cloud_health._get_api_call.assert_called_once_with(
             CloudHealthTest.COST_CURRENT_REPORT,
-            CloudHealthTest.API_KEY
-            )
+            CloudHealthTest.API_KEY,
+        )
         self.cloud_health._get_data.assert_called_once_with(
             CloudHealthTest.API_CALL,
             CloudHealthTest.COST_CURRENT_CATEGORY_TYPE,
-            None)
+            None,
+        )
 
     @patch('krux_cloud_health.cloud_health.pprint.pformat')
     @patch('krux_cloud_health.cloud_health.requests')
@@ -183,8 +191,8 @@ class CloudHealthTest(unittest.TestCase):
 
         mock_request.get.assert_called_once_with(
             CloudHealthTest.COST_HISTORY_URI,
-            params=CloudHealthTest.URI_ARGS_NO_PARAMS
-            )
+            params=CloudHealthTest.URI_ARGS_NO_PARAMS,
+        )
         mock_pprint.assert_called_once_with(CloudHealthTest.API_CALL)
         self.cloud_health.logger.debug.assert_called_once_with(mock_pprint(CloudHealthTest.API_CALL))
         self.assertEqual(get_api_call, CloudHealthTest.API_CALL)
@@ -200,7 +208,8 @@ class CloudHealthTest(unittest.TestCase):
         with self.assertRaises(ValueError) as ve:
             self.cloud_health._get_api_call(
                 CloudHealthTest.COST_HISTORY_REPORT,
-                CloudHealthTest.API_KEY)
+                CloudHealthTest.API_KEY,
+            )
         self.assertEqual(ve.exception.message, CloudHealthTest.API_CALL_ERROR.get('error'))
 
     def test_get_data(self):
@@ -208,16 +217,21 @@ class CloudHealthTest(unittest.TestCase):
         Cloud Health Test: Get Data method correctly gets category and service information from API call. It then
         passes information for each category into Get Data Info.
         """
-        get_data = self.cloud_health._get_data(CloudHealthTest.GET_DATA_API_CALL,
-            CloudHealthTest.COST_HISTORY_CATEGORY_TYPE)
+        get_data = self.cloud_health._get_data(
+            CloudHealthTest.GET_DATA_API_CALL,
+            CloudHealthTest.COST_HISTORY_CATEGORY_TYPE,
+        )
         self.assertEqual(get_data, CloudHealthTest.GET_DATA_RV)
 
     def test_get_data_category_name(self):
         """
         Cloud Health Test: Get Data method correctly filters out everything else, when category name is used.
         """
-        get_data = self.cloud_health._get_data(CloudHealthTest.GET_DATA_API_CALL,
-            CloudHealthTest.COST_HISTORY_CATEGORY_TYPE, 'date1')
+        get_data = self.cloud_health._get_data(
+            CloudHealthTest.GET_DATA_API_CALL,
+            CloudHealthTest.COST_HISTORY_CATEGORY_TYPE,
+            'date1'
+        )
         self.assertEqual(get_data, CloudHealthTest.GET_DATA_INFO_RV)
 
     def test_get_data_info(self):
@@ -229,5 +243,6 @@ class CloudHealthTest(unittest.TestCase):
             CloudHealthTest.GET_DATA_API_CALL,
             CloudHealthTest.ITEMS_LIST,
             'date1',
-            0)
+            0,
+        )
         self.assertEqual(get_data_info,  CloudHealthTest.GET_DATA_INFO_RV)

--- a/tests/krux_cloud_health/cloud_health_test.py
+++ b/tests/krux_cloud_health/cloud_health_test.py
@@ -35,7 +35,7 @@ class CloudHealthTest(unittest.TestCase):
     TIME_INPUT = 'time_input'
     COST_HISTORY_CATEGORY_TYPE = 'time'
     COST_CURRENT_CATEGORY_TYPE = 'AWS-Account'
-    PARAMS_INTERVAL = {'interval': 'daily'} 
+    PARAMS_INTERVAL = {'interval': 'daily'}
     PARAMS_TIME_INPUT = {'interval': 'daily', 'filters[]': 'time:select:{}'.format(TIME_INPUT)}
     API_CALL = {'api_call': 'return'}
     API_CALL_ERROR = {'error': 'Error message'}
@@ -43,7 +43,7 @@ class CloudHealthTest(unittest.TestCase):
                     {'label': 'service2', 'parent': 1},
                     {'label': 'service3', 'parent': 1}]
     GET_DATA_API_CALL = {'dimensions': [
-                            {'time': 
+                            {'time':
                                 [
                                     {'label': 'date1'},
                                     {'label': 'date2'}
@@ -69,7 +69,7 @@ class CloudHealthTest(unittest.TestCase):
     GET_DATA_INFO_RV = {'date1': {'service2': 2.25, 'service3': None}}
     GET_DATA_RV = {'date1': {'service2': 2.25, 'service3': None},
             'date2': {'service2': 4.11, 'service3': None}}
-    
+
     def setUp(self):
         self.cloud_health = get_cloud_health(args=MagicMock(api_key=CloudHealthTest.API_KEY))
 
@@ -213,6 +213,9 @@ class CloudHealthTest(unittest.TestCase):
         self.assertEqual(get_data, CloudHealthTest.GET_DATA_RV)
 
     def test_get_data_category_name(self):
+        """
+        Cloud Health Test: Get Data method correctly filters out everything else, when category name is used.
+        """
         get_data = self.cloud_health._get_data(CloudHealthTest.GET_DATA_API_CALL,
             CloudHealthTest.COST_HISTORY_CATEGORY_TYPE, 'date1')
         self.assertEqual(get_data, CloudHealthTest.GET_DATA_INFO_RV)


### PR DESCRIPTION
## What does this PR do?
This PR adds `--date-format` CLI argument to `cloud-health-to-graphite` CLI application.

## Why is this change being made?
Cloud Health returns differently formatted date depending on the time interval of the report.

## How was this tested? How can the reviewer verify your testing?
The changes were tested manually in the development environment and via unit tests.

## Where should the reviewer start?
`bin/cloud_health_to_graphite.py` carries the actual change and `tests/bin/cloud_health_to_graphite_test.py` has the corresponding unit test change.
Changes in `tests/krux_cloud_health/cloud_health_test.py` is all noop change and was made for PEP8 compliance.

## Completion checklist

- [x] The pull request has been appropriately labelled according to
  our [conventions](https://kruxdigital.jira.com/wiki/display/EN/Changes+and+Peer+Review)
- [x] The change has unit & integration tests as appropriate.