### PR TITLE
Incrementing patch version to fix a build error

### DIFF
--- a/krux_cloud_health/__init__.py
+++ b/krux_cloud_health/__init__.py
@@ -1,1 +1,1 @@
-VERSION = '0.2.1'
+VERSION = '0.2.2'


### PR DESCRIPTION
There was a build error with version 0.2.1. This should trigger a new build that fixes the error.