### PR TITLE
PE-3457: Adding --interval support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@ __pycache__/
 
 # Distribution / packaging
 .Python
-env/
 build/
 develop-eggs/
 dist/
@@ -20,6 +19,7 @@ lib64/
 parts/
 sdist/
 var/
+wheels/
 *.egg-info/
 .installed.cfg
 *.egg
@@ -37,14 +37,14 @@ pip-delete-this-directory.txt
 # Unit test / coverage reports
 htmlcov/
 .tox/
-cover/
 .coverage
 .coverage.*
 .cache
 nosetests.xml
 coverage.xml
-*,cover
+*.cover
 .hypothesis/
+cover/
 .noseids
 
 # Translations
@@ -68,7 +68,7 @@ docs/_build/
 # PyBuilder
 target/
 
-# IPython Notebook
+# Jupyter Notebook
 .ipynb_checkpoints
 
 # pyenv
@@ -77,18 +77,28 @@ target/
 # celery beat schedule file
 celerybeat-schedule
 
-# dotenv
-.env
+# SageMath parsed files
+*.sage.py
 
-# virtualenv
+# Environments
+.env
+.venv
+env/
 venv/
 ENV/
 
 # Spyder project settings
 .spyderproject
+.spyproject
 
 # Rope project settings
 .ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
 
 # JetBrain IDE settings
 .idea/

--- a/bin/cloud_health_to_graphite.py
+++ b/bin/cloud_health_to_graphite.py
@@ -28,6 +28,7 @@ from six import iteritems
 
 from krux.cli import get_group
 from krux_cloud_health import VERSION
+from krux_cloud_health.cloud_health import Interval
 import krux_cloud_health.cli
 
 
@@ -44,6 +45,8 @@ class Application(krux_cloud_health.cli.Application):
 
         # XXX: Empty space and period causes issues with graphite. Replace it with underscore.
         self.report_name = Application._sanitize_stats(self.args.report_name)
+
+        self.interval = Interval[self.args.interval]
 
     def add_cli_arguments(self, parser):
         """
@@ -83,13 +86,25 @@ class Application(krux_cloud_health.cli.Application):
             help="Format string to use to parse the date passed by Cloud Health (default: %(default)s)",
         )
 
+        group.add_argument(
+            '--interval',
+            type=str,
+            choices=[interval.name for interval in Interval],
+            default=Interval.hourly.name,
+            help="Time interval to be used in report (default: %(default)s)",
+        )
+
     @staticmethod
     def _sanitize_stats(stat_name):
         return re.sub(Application._INVALID_STATS_PATTERN, '_', stat_name)
 
     def run(self):
         try:
-            report_data = self.cloud_health.get_custom_report(report_id=self.args.report_id, category=self.args.set_date)
+            report_data = self.cloud_health.get_custom_report(
+                report_id=self.args.report_id,
+                category=self.args.set_date,
+                time_interval=self.interval,
+            )
             self.logger.debug(pprint.pformat(report_data))
         except (ValueError, IndexError) as e:
             self.logger.error(e.message)

--- a/bin/cloud_health_to_graphite.py
+++ b/bin/cloud_health_to_graphite.py
@@ -109,7 +109,6 @@ class Application(krux_cloud_health.cli.Application):
         except (ValueError, IndexError) as e:
             self.logger.error(e.message)
             self.exit(1)
-            return
 
         if 'Total' in report_data:
             del report_data['Total']

--- a/bin/cloud_health_to_graphite.py
+++ b/bin/cloud_health_to_graphite.py
@@ -110,11 +110,13 @@ class Application(krux_cloud_health.cli.Application):
             self.logger.error(e.message)
             self.exit(1)
 
+        # API always returns a set of dates and a total for the keys of the dictionary. We don't need the total
+        # value. Ignore it here.
         if 'Total' in report_data:
             del report_data['Total']
 
         for date, values in iteritems(report_data):
-            date = int(calendar.timegm(datetime.strptime(date, self.args.date_format).utctimetuple()))
+            posix_date = int(calendar.timegm(datetime.strptime(date, self.args.date_format).utctimetuple()))
 
             for category, cost in iteritems(values):
                 # XXX: Empty space and period causes issues with graphite. Replace it with underscore.
@@ -125,7 +127,7 @@ class Application(krux_cloud_health.cli.Application):
                         report_name=self.report_name,
                         category=category,
                         cost=cost,
-                        date=date,
+                        date=posix_date,
                     ))
 
 

--- a/krux_cloud_health/__init__.py
+++ b/krux_cloud_health/__init__.py
@@ -1,1 +1,1 @@
-VERSION = '0.2.3'
+VERSION = '0.3.0'

--- a/krux_cloud_health/cloud_health.py
+++ b/krux_cloud_health/cloud_health.py
@@ -109,9 +109,11 @@ class CloudHealth(object):
 
         return self._get_data(api_call, 'AWS-Account', aws_account_input)
 
-    def get_custom_report(self, report_id, category=None):
+    def get_custom_report(self, report_id, category=None, time_interval=Interval.hourly):
         report = 'olap_reports/custom/{report_id}'.format(report_id=report_id)
-        api_call = self._get_api_call(report, self.api_key)
+        params = {'interval': time_interval.name}
+
+        api_call = self._get_api_call(report, self.api_key, params)
 
         self.logger.debug(api_call)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,3 +9,6 @@ cover-package = krux_cloud_health, bin
 verbosity = 2
 with-coverage = 1
 with-id = 1
+
+[coverage:report]
+show_missing = True

--- a/tests/bin/cloud_health_to_graphite_test.py
+++ b/tests/bin/cloud_health_to_graphite_test.py
@@ -63,6 +63,8 @@ class CloudHealthAPITest(unittest.TestCase):
 
         dt = datetime.today()
         dt_diff = {
+            # GOTCHA: This is technically not always a month incremental. However, the main purpose of this mocking is
+            #         to test the datetime format string. Thus, leaving this as is for the maintainability and readability.
             Interval.monthly: {'days': 30},
             Interval.weekly: {'days': 7},
             Interval.daily: {'days': 1},
@@ -250,10 +252,12 @@ class CloudHealthAPITest(unittest.TestCase):
             self.REPORT_ID, time_interval=self.INTERVAL,
         )
         for date, values in iteritems(api_data):
+            # API always returns a set of dates and a total for the keys of the dictionary. We don't need the total
+            # value. Ignore it here.
             if date is 'Total':
                 continue
 
-            date = int(calendar.timegm(datetime.strptime(date, self._DEFAULT_DATE_FORMAT).utctimetuple()))
+            posix_date = int(calendar.timegm(datetime.strptime(date, self._DEFAULT_DATE_FORMAT).utctimetuple()))
 
             for category, cost in iteritems(values):
                 if cost is not None:
@@ -262,7 +266,7 @@ class CloudHealthAPITest(unittest.TestCase):
                         report_name=self.REPORT_NAME,
                         category=category,
                         cost=cost,
-                        date=date,
+                        date=posix_date,
                     )
 
         self.assertEqual(prints, mock_stdout.getvalue())

--- a/tests/krux_cloud_health/cloud_health_test.py
+++ b/tests/krux_cloud_health/cloud_health_test.py
@@ -28,6 +28,7 @@ class CloudHealthTest(unittest.TestCase):
     API_KEY = '12345'
     COST_HISTORY_REPORT = 'olap_reports/cost/history'
     COST_CURRENT_REPORT = 'olap_reports/cost/current'
+    CUSTOM_REPORT_TEMPLATE = 'olap_reports/custom/{report_id}'
     API_ENDPOINT = 'https://apps.cloudhealthtech.com/'
     COST_HISTORY_URI = '{}{}'.format(API_ENDPOINT, COST_HISTORY_REPORT)
     URI_ARGS_NO_PARAMS = {'api_key': API_KEY}
@@ -74,6 +75,7 @@ class CloudHealthTest(unittest.TestCase):
         'date1': {'service2': 2.25, 'service3': None},
         'date2': {'service2': 4.11, 'service3': None},
     }
+    REPORT_ID = 1234567890
 
     def setUp(self):
         self.cloud_health = get_cloud_health(args=MagicMock(api_key=CloudHealthTest.API_KEY))
@@ -176,6 +178,45 @@ class CloudHealthTest(unittest.TestCase):
             CloudHealthTest.API_CALL,
             CloudHealthTest.COST_CURRENT_CATEGORY_TYPE,
             None,
+        )
+
+    def test_get_custom_report_default(self):
+        """
+        Cloud Health Test: Custom report method properly passes in arguments to Get API call method with default arguments.
+        """
+        self.cloud_health._get_api_call = MagicMock(return_value=CloudHealthTest.API_CALL)
+        self.cloud_health._get_data = MagicMock()
+
+        self.cloud_health.get_custom_report(report_id=CloudHealthTest.REPORT_ID)
+
+        self.cloud_health._get_api_call.assert_called_once_with(
+            CloudHealthTest.CUSTOM_REPORT_TEMPLATE.format(report_id=CloudHealthTest.REPORT_ID),
+            CloudHealthTest.API_KEY,
+            {'interval': Interval.hourly.name}
+        )
+        self.cloud_health._get_data.assert_called_once_with(
+            CloudHealthTest.API_CALL, category_name=None, exclude_summary=False
+        )
+
+    def test_get_custom_report_parameters(self):
+        """
+        Cloud Health Test: Custom report method properly passes in arguments to Get API call method with passed arguments.
+        """
+        self.cloud_health._get_api_call = MagicMock(return_value=CloudHealthTest.API_CALL)
+        self.cloud_health._get_data = MagicMock()
+
+        category = 'category'
+        self.cloud_health.get_custom_report(
+            report_id=CloudHealthTest.REPORT_ID, category=category, time_interval=Interval.daily
+        )
+
+        self.cloud_health._get_api_call.assert_called_once_with(
+            CloudHealthTest.CUSTOM_REPORT_TEMPLATE.format(report_id=CloudHealthTest.REPORT_ID),
+            CloudHealthTest.API_KEY,
+            {'interval': Interval.daily.name}
+        )
+        self.cloud_health._get_data.assert_called_once_with(
+            CloudHealthTest.API_CALL, category_name=category, exclude_summary=False
         )
 
     @patch('krux_cloud_health.cloud_health.pprint.pformat')


### PR DESCRIPTION
## What does this PR do?

This PR adds support for `--interval` in `cloud-health-to-graphite`. This PR also update the `.gitignore` file and makes some minor unit testing fixes.

## Why is this change being made?

`--interval` allows us to pull existing report with a different time interval than what the report is built with. This allows us to display report in one time interval for Cloud Health UI and export data in more detailed format.

## How does this PR do it?

`--interval` is passed to Cloud Heath Tech's API as `interval` query string parameter.

## How was this tested? How can the reviewer verify your testing?

The change was manually tested on development environment as well as via unit tests.

## What gif best describes this PR or how it makes you feel?

![](https://media.giphy.com/media/wKXH7bkRB9Wpy/giphy.gif)

## Completion checklist

- [X] The pull request has been appropriately labeled according to
  our [conventions](https://kruxdigital.jira.com/wiki/display/EN/Changes+and+Peer+Review)
- [X] The change has unit & integration tests as appropriate.
- [X] Stakeholders have been notified. Workflow-impacting changes have
      been appropriately socialized to avoid surprises.